### PR TITLE
Update and rename Shedulepowershellwithencodedcommandparameter.yml to…

### DIFF
--- a/rules/Schedulepowershellwithencodedcommandparameter.yml
+++ b/rules/Schedulepowershellwithencodedcommandparameter.yml
@@ -1,6 +1,6 @@
-title: Shedule powershell with encoded command parameter
+title: Schedule powershell with encoded command parameter
 status: experimental
-description: Shedule powershell with encoded command parameter
+description: Schedule powershell with encoded command parameter
 author: Joe Security
 date: 2021-03-08
 id: 200100


### PR DESCRIPTION
… Schedulepowershellwithencodedcommandparameter.yml

Fixes typo of `shedule` to `schedule`